### PR TITLE
fix: Error decoding command output on Windows

### DIFF
--- a/biliupload/login/login_bili.py
+++ b/biliupload/login/login_bili.py
@@ -26,7 +26,9 @@ def execute_curl_command(api, data):
     data_string = map_to_string(data)
     headers = "Content-Type: application/x-www-form-urlencoded"
     curl_command = f"curl -X POST -H \"{headers}\" -d \"{data_string}\" {api}"
-    result = subprocess.run(curl_command, shell=True, capture_output=True, text=True)
+    result = subprocess.run(
+        curl_command, shell=True, capture_output=True, text=True, encoding="utf-8"
+    )
     if result.returncode != 0:
         raise Exception(f"curl command failed: {result.stderr}")
     return json.loads(result.stdout)


### PR DESCRIPTION
## Description

This PR resolves a `UnicodeDecodeError` that occurs on Windows systems when decoding command output. The issue arises due to the default encoding (`gbk`) being unable to handle certain byte sequences, as shown in the error traceback:

```
Traceback (most recent call last):
  File "C:\Users\wangz\.conda\envs\llm\Lib\threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "C:\Users\wangz\.conda\envs\llm\Lib\threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\wangz\.conda\envs\llm\Lib\subprocess.py", line 1599, in _readerthread
    buffer.append(fh.read())
                  ^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaa in position 39: illegal multibyte sequence
```

Additionally, the error propagates to cause a `TypeError` when attempting to parse `None` as JSON:

```
Traceback (most recent call last):
  File "C:\Users\wangz\Projects\github\ytbili\biliup\__init__.py", line 273, in <module>
    bup.login()
  File "C:\Users\wangz\Projects\github\ytbili\biliup\__init__.py", line 212, in login
    login_bili(export_cookie)
  File "C:\Users\wangz\.conda\envs\llm\Lib\site-packages\biliupload\login\login_bili.py", line 83, in login_bili
    verify_login(auth_code, export)
  File "C:\Users\wangz\.conda\envs\llm\Lib\site-packages\biliupload\login\login_bili.py", line 58, in verify_login
    body = execute_curl_command(api, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wangz\.conda\envs\llm\Lib\site-packages\biliupload\login\login_bili.py", line 32, in execute_curl_command
    return json.loads(result.stdout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\wangz\.conda\envs\llm\Lib\json\__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

This fix ensures proper handling of command output encoding to prevent such errors.