### PR TITLE
feat: add query ip module

### DIFF
--- a/biliupload/cli.py
+++ b/biliupload/cli.py
@@ -13,6 +13,7 @@ from biliupload.controller.upload_controller import UploadController
 from biliupload.login.check_login import CheckLogin
 from biliupload.login.logout_bili import Logout
 from biliupload.controller.download_controller import DownloadController
+from biliupload.utils.get_ip_info import IPInfo
 
 def cli():
     logging.basicConfig(
@@ -57,6 +58,9 @@ def cli():
     download_parser.add_argument('--chunksize', type=int, default=1024, help='(default is 1024) the chunk size of video')
     download_parser.add_argument('--multiple', action='store_true', help='(default is false) download the multiple videos if have set')
 
+    ip_parser = subparsers.add_parser('ip', help='Get the ip info')
+    ip_parser.add_argument('--ip', default='', help='(default is your request ip) The ip address')
+
     args = parser.parse_args()
 
     # Check if no subcommand is provided
@@ -94,6 +98,9 @@ def cli():
         ioer().update_multiple_config(args.subcommand, download_metadata)
         download_controller = DownloadController()
         download_controller.download_video(args.bvid)
+
+    if args.subcommand == 'ip':
+        IPInfo.get_ip_address(args.ip)
 
 if __name__ == '__main__':
     cli()

--- a/biliupload/utils/get_ip_info.py
+++ b/biliupload/utils/get_ip_info.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2025 biliupload
+
+import http.client
+import urllib.parse
+import json
+
+class IPInfo:
+    @staticmethod
+    def get_ip_address(ip=None):
+        url = 'https://api.live.bilibili.com/ip_service/v1/ip_service/get_ip_addr'
+        if ip:
+            params = urllib.parse.urlencode({'ip': ip})
+            full_url = f"{url}?{params}"
+        else:
+            full_url = url
+
+        parsed_url = urllib.parse.urlparse(full_url)
+        host = parsed_url.netloc
+        path = parsed_url.path + ('?' + parsed_url.query if parsed_url.query else '')
+
+        connection = http.client.HTTPSConnection(host)
+        connection.request("GET", path)
+
+        response = connection.getresponse()
+        data = json.loads(response.read().decode('utf-8'))
+        connection.close()
+
+        return IPInfo.print_ip_info(data)
+
+    @staticmethod
+    def print_ip_info(ip_info):
+        if ip_info['code'] != 0:
+            return None
+        else:
+            addr = ip_info['data']['addr']
+            isp = ip_info['data']['isp']
+            location = ip_info['data']['country'] + ip_info['data']['province'] + ip_info['data']['city']
+            position = ip_info['data']['latitude'] + ',' + ip_info['data']['longitude']
+            print(f"IP: {addr}, ISP: {isp}, Location: {location}, Position: {position}")
+            return addr, isp, location, position

--- a/tests/test_get_ip_info.py
+++ b/tests/test_get_ip_info.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2025 biliupload
+
+import unittest
+from biliupload.utils.get_ip_info import IPInfo
+
+class TestIPInfo(unittest.TestCase):
+    def test_get_ip_address(self):
+        self.assertEqual(IPInfo.get_ip_address('12.12.12.12'), 
+        ('12.12.12.12', 'att.com', '美国阿拉斯加州安克雷奇', '61.108841,-149.373145'))
+ 


### PR DESCRIPTION
## Description

Add query ip module.
The multiple requests operation has the risk of been suspended by the official. You can consider using the proxy, so the query ip module can help you ensure the ip status of yours.

## Changes Proposed

- [ ] add query ip module
- [ ] add some test cases

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
